### PR TITLE
Update API documentation to v15

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ What
 ------------
 Public API description for Yazio application.
 
+Documented API version: **v15** (`https://yzapi.yazio.com/v15`)
+
 Why?
 ------------
 After waiting for more than one year for public API description I was tired.
@@ -21,7 +23,7 @@ Documentation
 
 A `swagger.json` file was added. You can use the public [swagger editor](https://editor-next.swagger.io/) to paste/import it and play around.
 
-ℹ️ The OAuth part works. You can log in and retrieve a valid token.
+ℹ️ The OAuth part works. Authenticate via `POST /oauth/token` with `Content-Type: application/x-www-form-urlencoded` (not JSON). You can log in and retrieve a valid token.
 
 ⚠️ The other endpoints won't work in the swagger UI, as long as you are playing around using the public swagger editor. The reason is that yazio has CORS security rules enabled that can only be omitted using HTTP or localhost clients. [You can use the client credentials that are posted in this repository](https://github.com/saganos/yazio_public_api/blob/master/examples/login.js).
 
@@ -48,5 +50,20 @@ node examples/token_refresh.js
 node examples/get_user_info.js
 ```
 
-[get_user_info.js](examples/get_user_info.js) - Gets user info 
+[get_user_info.js](examples/get_user_info.js) - Gets user info
 
+----
+### Search products ###
+```bash
+node examples/search_products.js
+```
+
+[search_products.js](examples/search_products.js) - Search for food products by name
+
+----
+### Get diary entries ###
+```bash
+node examples/get_diary.js
+```
+
+[get_diary.js](examples/get_diary.js) - Get consumed items (food diary) for a given date

--- a/docs/superpowers/plans/2026-05-09-missing-endpoints.md
+++ b/docs/superpowers/plans/2026-05-09-missing-endpoints.md
@@ -1,0 +1,476 @@
+# Missing YAZIO Endpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 6 endpoints from `juriadams/yazio` reference repo to `swagger.json` and create one runnable example JS script per endpoint.
+
+**Architecture:** All changes touch two areas: (1) `swagger.json` gets new `tags`, `paths`, and `definitions` entries; (2) `examples/` gets one plain-Node.js script per endpoint matching the existing style (`fetch`, hardcoded bearer token placeholder, `console.log`).
+
+**Tech Stack:** Swagger 2.0 JSON, plain Node.js (no dependencies, native `fetch`)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `swagger.json` | Modify | Add 4 new tags, 6 new paths, 6 new schema definitions |
+| `examples/get_dietary_preferences.js` | Create | Demo `GET /user/dietary-preferences` |
+| `examples/get_exercises.js` | Create | Demo `GET /user/exercises?date=` |
+| `examples/get_goals.js` | Create | Demo `GET /user/goals/unmodified?date=` |
+| `examples/get_settings.js` | Create | Demo `GET /user/settings` |
+| `examples/get_weight.js` | Create | Demo `GET /user/bodyvalues/weight/last?date=` |
+| `examples/get_suggested_products.js` | Create | Demo `GET /user/products/suggested?date=&daytime=` |
+
+---
+
+### Task 1: Extend swagger.json — tags, paths, definitions
+
+**Files:**
+- Modify: `swagger.json`
+
+- [ ] **Step 1: Add 4 new tags** inside the `"tags"` array (after the existing `"water"` tag):
+
+```json
+{ "name": "exercises",  "description": "User exercise and training log" },
+{ "name": "goals",      "description": "User nutrition and activity goals" },
+{ "name": "settings",   "description": "User app settings and preferences" },
+{ "name": "bodyvalues", "description": "Body measurements (weight, etc.)" }
+```
+
+- [ ] **Step 2: Add 6 new paths** inside the `"paths"` object (after `/user/water-intake`):
+
+```json
+"/user/dietary-preferences": {
+    "get": {
+        "tags": ["user"],
+        "summary": "Get dietary preferences",
+        "description": "Returns the user's dietary restriction (e.g. vegetarian, vegan).",
+        "security": [{ "oauth2": [] }],
+        "responses": {
+            "200": {
+                "description": "Dietary preferences",
+                "schema": { "$ref": "#/definitions/UserDietaryPreferences" }
+            }
+        }
+    }
+},
+"/user/exercises": {
+    "get": {
+        "tags": ["exercises"],
+        "summary": "Get exercises for a date",
+        "description": "Returns training and custom_training entries logged by the user for a specific day.",
+        "security": [{ "oauth2": [] }],
+        "parameters": [
+            { "name": "date", "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" }
+        ],
+        "responses": {
+            "200": {
+                "description": "Exercise entries",
+                "schema": { "$ref": "#/definitions/UserExercisesResponse" }
+            }
+        }
+    }
+},
+"/user/goals/unmodified": {
+    "get": {
+        "tags": ["goals"],
+        "summary": "Get user goals for a date",
+        "description": "Returns calorie, macro, water, step, and weight goals for the specified day.",
+        "security": [{ "oauth2": [] }],
+        "parameters": [
+            { "name": "date", "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" }
+        ],
+        "responses": {
+            "200": {
+                "description": "User goals",
+                "schema": { "$ref": "#/definitions/UserGoals" }
+            }
+        }
+    }
+},
+"/user/settings": {
+    "get": {
+        "tags": ["settings"],
+        "summary": "Get user settings",
+        "description": "Returns boolean feature flags for trackers, reminders, and other app settings.",
+        "security": [{ "oauth2": [] }],
+        "responses": {
+            "200": {
+                "description": "User settings",
+                "schema": { "$ref": "#/definitions/UserSettings" }
+            }
+        }
+    }
+},
+"/user/bodyvalues/weight/last": {
+    "get": {
+        "tags": ["bodyvalues"],
+        "summary": "Get last weight entry",
+        "description": "Returns the most recent weight entry for the user on or before the given date, or null if none exists.",
+        "security": [{ "oauth2": [] }],
+        "parameters": [
+            { "name": "date", "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" }
+        ],
+        "responses": {
+            "200": {
+                "description": "Weight entry or null",
+                "schema": { "$ref": "#/definitions/UserWeight" }
+            }
+        }
+    }
+},
+"/user/products/suggested": {
+    "get": {
+        "tags": ["products"],
+        "summary": "Get suggested products for a meal slot",
+        "description": "Returns products suggested for the user based on their history for a specific date and meal (daytime).",
+        "security": [{ "oauth2": [] }],
+        "parameters": [
+            { "name": "date",    "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" },
+            { "name": "daytime", "in": "query", "required": true, "type": "string", "enum": ["breakfast", "lunch", "dinner", "snack"] }
+        ],
+        "responses": {
+            "200": {
+                "description": "Suggested products",
+                "schema": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/UserSuggestedProduct" }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add 6 new schema definitions** inside the `"definitions"` object (after `WaterIntakeEntry`):
+
+```json
+"UserDietaryPreferences": {
+    "type": "object",
+    "properties": {
+        "restriction": { "type": "string", "nullable": true, "example": "vegetarian", "description": "Dietary restriction label, or null if none" }
+    }
+},
+"Exercise": {
+    "type": "object",
+    "properties": {
+        "id":          { "type": "string", "format": "uuid" },
+        "note":        { "type": "string", "nullable": true },
+        "date":        { "type": "string", "example": "2024-01-15 08:00:00" },
+        "name":        { "type": "string" },
+        "external_id": { "type": "string", "nullable": true },
+        "energy":      { "type": "number", "description": "Calories burned" },
+        "distance":    { "type": "number" },
+        "duration":    { "type": "number", "description": "Duration in seconds" },
+        "source":      { "type": "string", "nullable": true },
+        "gateway":     { "type": "string", "nullable": true },
+        "steps":       { "type": "number" }
+    }
+},
+"UserExercisesResponse": {
+    "type": "object",
+    "properties": {
+        "training":        { "type": "array", "items": { "$ref": "#/definitions/Exercise" } },
+        "custom_training": { "type": "array", "items": { "$ref": "#/definitions/Exercise" } }
+    }
+},
+"UserGoals": {
+    "type": "object",
+    "description": "Daily goals for the user",
+    "properties": {
+        "energy.energy":      { "type": "number", "description": "Calorie goal in kcal" },
+        "nutrient.protein":   { "type": "number", "description": "Protein goal in grams" },
+        "nutrient.fat":       { "type": "number", "description": "Fat goal in grams" },
+        "nutrient.carb":      { "type": "number", "description": "Carbohydrate goal in grams" },
+        "activity.step":      { "type": "number", "description": "Step count goal" },
+        "bodyvalue.weight":   { "type": "number", "description": "Target weight in kg" },
+        "water":              { "type": "number", "description": "Water intake goal in ml" }
+    }
+},
+"UserSettings": {
+    "type": "object",
+    "properties": {
+        "has_water_tracker":               { "type": "boolean" },
+        "has_diary_tipps":                 { "type": "boolean" },
+        "has_meal_reminders":              { "type": "boolean" },
+        "has_usage_reminders":             { "type": "boolean" },
+        "has_weight_reminders":            { "type": "boolean" },
+        "has_water_reminders":             { "type": "boolean" },
+        "consume_activity_calories":       { "type": "boolean" },
+        "has_feelings":                    { "type": "boolean" },
+        "has_fasting_tracker_reminders":   { "type": "boolean" },
+        "has_fasting_stage_reminders":     { "type": "boolean" }
+    }
+},
+"UserWeight": {
+    "type": "object",
+    "nullable": true,
+    "properties": {
+        "id":          { "type": "string", "format": "uuid" },
+        "date":        { "type": "string", "example": "2024-01-15 08:00:00" },
+        "value":       { "type": "number", "nullable": true, "description": "Weight in kg" },
+        "external_id": { "type": "string", "nullable": true },
+        "gateway":     { "type": "string", "nullable": true },
+        "source":      { "type": "string", "nullable": true }
+    }
+},
+"UserSuggestedProduct": {
+    "type": "object",
+    "properties": {
+        "product_id":       { "type": "string", "format": "uuid" },
+        "amount":           { "type": "number", "description": "Amount in grams" },
+        "serving":          { "type": "string", "nullable": true },
+        "serving_quantity": { "type": "number", "nullable": true }
+    }
+}
+```
+
+- [ ] **Step 4: Validate swagger.json is valid JSON**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('swagger.json','utf8')); console.log('valid')"
+```
+
+Expected output: `valid`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add swagger.json
+git commit -m "feat: add 6 missing endpoints from juriadams/yazio reference"
+```
+
+---
+
+### Task 2: Example script — dietary preferences
+
+**Files:**
+- Create: `examples/get_dietary_preferences.js`
+
+Reference style: `examples/get_user_info.js`
+
+- [ ] **Step 1: Create the file**
+
+```js
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+
+fetch(`${BASE_URL}/user/dietary-preferences`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);
+```
+
+- [ ] **Step 2: Verify script runs without syntax errors**
+
+```bash
+node --check examples/get_dietary_preferences.js
+```
+
+Expected: no output (exit 0)
+
+---
+
+### Task 3: Example script — exercises
+
+**Files:**
+- Create: `examples/get_exercises.js`
+
+- [ ] **Step 1: Create the file**
+
+```js
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+const DATE = new Date().toISOString().slice(0, 10);
+
+fetch(`${BASE_URL}/user/exercises?date=${DATE}`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);
+```
+
+- [ ] **Step 2: Verify script runs without syntax errors**
+
+```bash
+node --check examples/get_exercises.js
+```
+
+Expected: no output (exit 0)
+
+---
+
+### Task 4: Example script — goals
+
+**Files:**
+- Create: `examples/get_goals.js`
+
+- [ ] **Step 1: Create the file**
+
+```js
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+const DATE = new Date().toISOString().slice(0, 10);
+
+fetch(`${BASE_URL}/user/goals/unmodified?date=${DATE}`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);
+```
+
+- [ ] **Step 2: Verify script runs without syntax errors**
+
+```bash
+node --check examples/get_goals.js
+```
+
+Expected: no output (exit 0)
+
+---
+
+### Task 5: Example script — settings
+
+**Files:**
+- Create: `examples/get_settings.js`
+
+- [ ] **Step 1: Create the file**
+
+```js
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+
+fetch(`${BASE_URL}/user/settings`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);
+```
+
+- [ ] **Step 2: Verify script runs without syntax errors**
+
+```bash
+node --check examples/get_settings.js
+```
+
+Expected: no output (exit 0)
+
+---
+
+### Task 6: Example script — weight
+
+**Files:**
+- Create: `examples/get_weight.js`
+
+- [ ] **Step 1: Create the file**
+
+```js
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+const DATE = new Date().toISOString().slice(0, 10);
+
+fetch(`${BASE_URL}/user/bodyvalues/weight/last?date=${DATE}`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);
+```
+
+- [ ] **Step 2: Verify script runs without syntax errors**
+
+```bash
+node --check examples/get_weight.js
+```
+
+Expected: no output (exit 0)
+
+---
+
+### Task 7: Example script — suggested products
+
+**Files:**
+- Create: `examples/get_suggested_products.js`
+
+- [ ] **Step 1: Create the file**
+
+```js
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+const DATE = new Date().toISOString().slice(0, 10);
+const DAYTIME = "breakfast"; // change to: lunch | dinner | snack
+
+fetch(`${BASE_URL}/user/products/suggested?date=${DATE}&daytime=${DAYTIME}`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);
+```
+
+- [ ] **Step 2: Verify script runs without syntax errors**
+
+```bash
+node --check examples/get_suggested_products.js
+```
+
+Expected: no output (exit 0)
+
+---
+
+### Task 8: Commit example scripts and open PR
+
+**Files:**
+- All new `examples/get_*.js` files
+
+- [ ] **Step 1: Commit all example scripts**
+
+```bash
+git add examples/get_dietary_preferences.js examples/get_exercises.js examples/get_goals.js examples/get_settings.js examples/get_weight.js examples/get_suggested_products.js
+git commit -m "feat: add example scripts for 6 new endpoints"
+```
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin fix/api-endpoints-version-update
+```
+
+- [ ] **Step 3: Open PR targeting master**
+
+```bash
+gh pr create --base master --title "Add 6 missing API endpoints from juriadams/yazio reference" --body "$(cat <<'EOF'
+## Summary
+
+- Adds 6 endpoints present in the `juriadams/yazio` reference repo but missing from `swagger.json`:
+  - `GET /user/dietary-preferences`
+  - `GET /user/exercises`
+  - `GET /user/goals/unmodified`
+  - `GET /user/settings`
+  - `GET /user/bodyvalues/weight/last`
+  - `GET /user/products/suggested`
+- Adds 4 new swagger tags: `exercises`, `goals`, `settings`, `bodyvalues`
+- Adds 7 new schema definitions (including `Exercise`, `UserGoals`, `UserSettings`, `UserWeight`, `UserSuggestedProduct`, `UserDietaryPreferences`, `UserExercisesResponse`)
+- Adds one runnable example JS script per new endpoint
+
+## Test plan
+
+- [ ] `node --check examples/get_dietary_preferences.js` — no syntax errors
+- [ ] `node --check examples/get_exercises.js` — no syntax errors
+- [ ] `node --check examples/get_goals.js` — no syntax errors
+- [ ] `node --check examples/get_settings.js` — no syntax errors
+- [ ] `node --check examples/get_weight.js` — no syntax errors
+- [ ] `node --check examples/get_suggested_products.js` — no syntax errors
+- [ ] `swagger.json` imports cleanly into https://editor-next.swagger.io/
+- [ ] (with real token) each script returns expected JSON shape
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-09-missing-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-09-missing-endpoints-design.md
@@ -1,0 +1,48 @@
+# Missing Endpoints — Design Spec
+
+**Date:** 2026-05-09  
+**Branch:** based on `fix/api-endpoints-version-update`
+
+## Goal
+
+Add 6 endpoints present in the `juriadams/yazio` reference repo but missing from `swagger.json`. Add one example JS script per endpoint for manual testing.
+
+## Endpoints to Add
+
+| Path | Method | Tag | Description |
+|---|---|---|---|
+| `/user/dietary-preferences` | GET | `user` | Returns `{ restriction: string \| null }` |
+| `/user/exercises` | GET | `exercises` | Date param; returns `{ training, custom_training }` arrays |
+| `/user/goals/unmodified` | GET | `goals` | Date param; returns calorie/macro/step/weight goals object |
+| `/user/settings` | GET | `settings` | Returns boolean flags for app features/reminders |
+| `/user/bodyvalues/weight/last` | GET | `bodyvalues` | Date param; returns last weight entry or null |
+| `/user/products/suggested` | GET | `products` | Date + daytime params; returns suggested product array |
+
+## Schema Definitions to Add
+
+- `UserDietaryPreferences` — `{ restriction: string | null }`
+- `Exercise` — id, note, date, name, external_id, energy, distance, duration, source, gateway, steps
+- `UserGoals` — energy, protein, fat, carb, step, weight, water fields
+- `UserSettings` — boolean feature/reminder flags
+- `UserWeight` — id, date, value, external_id, gateway, source
+- `UserSuggestedProduct` — product_id, amount, serving, serving_quantity
+
+## Tags to Add
+
+New swagger tags: `exercises`, `goals`, `settings`, `bodyvalues`
+
+## Example Scripts
+
+One file per endpoint in `examples/`, matching existing style (plain Node.js, `fetch`, hardcoded bearer token placeholder):
+
+- `get_dietary_preferences.js`
+- `get_exercises.js`
+- `get_goals.js`
+- `get_settings.js`
+- `get_weight.js`
+- `get_suggested_products.js`
+
+## Out of Scope
+
+- Updating existing schema fields in `UserInfo`, `DailySummary`, `WaterIntakeEntry`
+- Adding POST/DELETE for any new endpoint (reference repo doesn't document them)

--- a/examples/get_diary.js
+++ b/examples/get_diary.js
@@ -1,0 +1,43 @@
+const fetch = require("node-fetch");
+global.Headers = fetch.Headers;
+
+var myHeaders = new Headers();
+myHeaders.append("Authorization", "Bearer __put_access_token_here__");
+
+var requestOptions = {
+  method: 'GET',
+  headers: myHeaders,
+  redirect: 'follow'
+};
+
+// Format: YYYY-MM-DD
+const date = "2024-01-15";
+
+fetch(`https://yzapi.yazio.com/v15/user/consumed-items?date=${date}`, requestOptions)
+  .then(response => {
+    if (response.status === 200) {
+      return response.json();
+    } else {
+      throw new Error('Something went wrong on api server!');
+    }
+  })
+  .then(response => {
+    console.debug(response);
+  }).catch(error => {
+    console.error(error);
+  });
+
+/*
+Json response (array of consumed items for the day):
+[
+  {
+    id: '__consumed_item_id__',
+    product_id: '__product_id__',
+    date: '2024-01-15 08:30:00',
+    daytime: 'breakfast',
+    amount: 150,
+    serving: 'g',
+    serving_quantity: 100
+  }
+]
+ */

--- a/examples/get_dietary_preferences.js
+++ b/examples/get_dietary_preferences.js
@@ -1,0 +1,9 @@
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+
+fetch(`${BASE_URL}/user/dietary-preferences`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);

--- a/examples/get_dietary_preferences.js
+++ b/examples/get_dietary_preferences.js
@@ -1,9 +1,13 @@
+// requires Node.js 18+ (uses native fetch, no dependencies)
 const BASE_URL = "https://yzapi.yazio.com/v15";
 const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
 
 fetch(`${BASE_URL}/user/dietary-preferences`, {
   headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
 })
-  .then((r) => r.json())
+  .then((r) => {
+    if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+    return r.json();
+  })
   .then((data) => console.log(JSON.stringify(data, null, 2)))
   .catch(console.error);

--- a/examples/get_exercises.js
+++ b/examples/get_exercises.js
@@ -1,3 +1,4 @@
+// requires Node.js 18+ (uses native fetch, no dependencies)
 const BASE_URL = "https://yzapi.yazio.com/v15";
 const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
 const DATE = new Date().toISOString().slice(0, 10);
@@ -5,6 +6,9 @@ const DATE = new Date().toISOString().slice(0, 10);
 fetch(`${BASE_URL}/user/exercises?date=${DATE}`, {
   headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
 })
-  .then((r) => r.json())
+  .then((r) => {
+    if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+    return r.json();
+  })
   .then((data) => console.log(JSON.stringify(data, null, 2)))
   .catch(console.error);

--- a/examples/get_exercises.js
+++ b/examples/get_exercises.js
@@ -1,0 +1,10 @@
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+const DATE = new Date().toISOString().slice(0, 10);
+
+fetch(`${BASE_URL}/user/exercises?date=${DATE}`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);

--- a/examples/get_goals.js
+++ b/examples/get_goals.js
@@ -1,3 +1,4 @@
+// requires Node.js 18+ (uses native fetch, no dependencies)
 const BASE_URL = "https://yzapi.yazio.com/v15";
 const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
 const DATE = new Date().toISOString().slice(0, 10);
@@ -5,6 +6,9 @@ const DATE = new Date().toISOString().slice(0, 10);
 fetch(`${BASE_URL}/user/goals/unmodified?date=${DATE}`, {
   headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
 })
-  .then((r) => r.json())
+  .then((r) => {
+    if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+    return r.json();
+  })
   .then((data) => console.log(JSON.stringify(data, null, 2)))
   .catch(console.error);

--- a/examples/get_goals.js
+++ b/examples/get_goals.js
@@ -1,0 +1,10 @@
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+const DATE = new Date().toISOString().slice(0, 10);
+
+fetch(`${BASE_URL}/user/goals/unmodified?date=${DATE}`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);

--- a/examples/get_settings.js
+++ b/examples/get_settings.js
@@ -1,9 +1,13 @@
+// requires Node.js 18+ (uses native fetch, no dependencies)
 const BASE_URL = "https://yzapi.yazio.com/v15";
 const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
 
 fetch(`${BASE_URL}/user/settings`, {
   headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
 })
-  .then((r) => r.json())
+  .then((r) => {
+    if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+    return r.json();
+  })
   .then((data) => console.log(JSON.stringify(data, null, 2)))
   .catch(console.error);

--- a/examples/get_settings.js
+++ b/examples/get_settings.js
@@ -1,0 +1,9 @@
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+
+fetch(`${BASE_URL}/user/settings`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);

--- a/examples/get_suggested_products.js
+++ b/examples/get_suggested_products.js
@@ -1,3 +1,4 @@
+// requires Node.js 18+ (uses native fetch, no dependencies)
 const BASE_URL = "https://yzapi.yazio.com/v15";
 const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
 const DATE = new Date().toISOString().slice(0, 10);
@@ -6,6 +7,9 @@ const DAYTIME = "breakfast"; // change to: lunch | dinner | snack
 fetch(`${BASE_URL}/user/products/suggested?date=${DATE}&daytime=${DAYTIME}`, {
   headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
 })
-  .then((r) => r.json())
+  .then((r) => {
+    if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+    return r.json();
+  })
   .then((data) => console.log(JSON.stringify(data, null, 2)))
   .catch(console.error);

--- a/examples/get_suggested_products.js
+++ b/examples/get_suggested_products.js
@@ -1,0 +1,11 @@
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+const DATE = new Date().toISOString().slice(0, 10);
+const DAYTIME = "breakfast"; // change to: lunch | dinner | snack
+
+fetch(`${BASE_URL}/user/products/suggested?date=${DATE}&daytime=${DAYTIME}`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);

--- a/examples/get_user_info.js
+++ b/examples/get_user_info.js
@@ -11,7 +11,7 @@ var requestOptions = {
   redirect: 'follow'
 };
 
-fetch('https://yzapi.yazio.com/v5/user', requestOptions)
+fetch('https://yzapi.yazio.com/v15/user', requestOptions)
   .then(response => {
     if (response.status === 200) {
       return response.json();

--- a/examples/get_weight.js
+++ b/examples/get_weight.js
@@ -1,3 +1,4 @@
+// requires Node.js 18+ (uses native fetch, no dependencies)
 const BASE_URL = "https://yzapi.yazio.com/v15";
 const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
 const DATE = new Date().toISOString().slice(0, 10);
@@ -5,6 +6,9 @@ const DATE = new Date().toISOString().slice(0, 10);
 fetch(`${BASE_URL}/user/bodyvalues/weight/last?date=${DATE}`, {
   headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
 })
-  .then((r) => r.json())
+  .then((r) => {
+    if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);
+    return r.json();
+  })
   .then((data) => console.log(JSON.stringify(data, null, 2)))
   .catch(console.error);

--- a/examples/get_weight.js
+++ b/examples/get_weight.js
@@ -1,0 +1,10 @@
+const BASE_URL = "https://yzapi.yazio.com/v15";
+const BEARER_TOKEN = "YOUR_ACCESS_TOKEN_HERE";
+const DATE = new Date().toISOString().slice(0, 10);
+
+fetch(`${BASE_URL}/user/bodyvalues/weight/last?date=${DATE}`, {
+  headers: { Authorization: `Bearer ${BEARER_TOKEN}` },
+})
+  .then((r) => r.json())
+  .then((data) => console.log(JSON.stringify(data, null, 2)))
+  .catch(console.error);

--- a/examples/login.js
+++ b/examples/login.js
@@ -1,14 +1,13 @@
 const fetch = require("node-fetch");
 
-const body = `{
-    "client_id": "1_4hiybetvfksgw40o0sog4s884kwc840wwso8go4k8c04goo4c",
-    "client_secret": "6rok2m65xuskgkgogw40wkkk8sw0osg84s8cggsc4woos4s8o",
-    "username": "_LOGIN_EMAIL_",
-    "password": "_PASSWORD_",
-    "grant_type": "password"
-}`;
+const params = new URLSearchParams();
+params.append("client_id", "1_4hiybetvfksgw40o0sog4s884kwc840wwso8go4k8c04goo4c");
+params.append("client_secret", "6rok2m65xuskgkgogw40wkkk8sw0osg84s8cggsc4woos4s8o");
+params.append("username", "_LOGIN_EMAIL_");
+params.append("password", "_PASSWORD_");
+params.append("grant_type", "password");
 
-fetch('https://yzapi.yazio.com/v5/oauth/token', {method: 'post', body: body})
+fetch('https://yzapi.yazio.com/v15/oauth/token', { method: 'post', body: params })
   .then(response => {
     if (response.status === 200) {
       return response.json();
@@ -19,8 +18,8 @@ fetch('https://yzapi.yazio.com/v5/oauth/token', {method: 'post', body: body})
   .then(response => {
     console.debug(response);
   }).catch(error => {
-  console.error(error);
-});
+    console.error(error);
+  });
 
 /*
 Json response:

--- a/examples/search_products.js
+++ b/examples/search_products.js
@@ -1,0 +1,55 @@
+const fetch = require("node-fetch");
+global.Headers = fetch.Headers;
+
+var myHeaders = new Headers();
+myHeaders.append("Authorization", "Bearer __put_access_token_here__");
+
+var requestOptions = {
+  method: 'GET',
+  headers: myHeaders,
+  redirect: 'follow'
+};
+
+// Adjust query, sex, countries, and locales to match your account settings
+const query = "apple";
+const sex = "male";
+const countries = "DE";
+const locales = "de_DE";
+
+const url = `https://yzapi.yazio.com/v15/products/search?query=${encodeURIComponent(query)}&sex=${sex}&countries=${countries}&locales=${locales}`;
+
+fetch(url, requestOptions)
+  .then(response => {
+    if (response.status === 200) {
+      return response.json();
+    } else {
+      throw new Error('Something went wrong on api server!');
+    }
+  })
+  .then(response => {
+    console.debug(response);
+  }).catch(error => {
+    console.error(error);
+  });
+
+/*
+Json response (array of search results):
+[
+  {
+    product_id: '__product_id__',
+    name: 'Apple',
+    producer: '',
+    serving: 'g',
+    serving_quantity: 100,
+    amount: 100,
+    base_unit: 'g',
+    nutrients: {
+      'energy.energy': 0.52,
+      'nutrient.protein': 0.003,
+      'nutrient.fat': 0.002,
+      'nutrient.carb': 0.138
+    },
+    is_verified: true
+  }
+]
+ */

--- a/examples/token_refresh.js
+++ b/examples/token_refresh.js
@@ -1,13 +1,12 @@
 const fetch = require("node-fetch");
 
-const body = `{
-    "client_id": "1_4hiybetvfksgw40o0sog4s884kwc840wwso8go4k8c04goo4c",
-    "client_secret": "6rok2m65xuskgkgogw40wkkk8sw0osg84s8cggsc4woos4s8o",
-    "grant_type": "refresh_token",
-    "refresh_token": "_refresh_token_here_"
-}`;
+const params = new URLSearchParams();
+params.append("client_id", "1_4hiybetvfksgw40o0sog4s884kwc840wwso8go4k8c04goo4c");
+params.append("client_secret", "6rok2m65xuskgkgogw40wkkk8sw0osg84s8cggsc4woos4s8o");
+params.append("grant_type", "refresh_token");
+params.append("refresh_token", "_refresh_token_here_");
 
-fetch('https://yzapi.yazio.com/v5/oauth/token', {method: 'post', body: body})
+fetch('https://yzapi.yazio.com/v15/oauth/token', { method: 'post', body: params })
   .then(response => {
     if (response.status === 200) {
       return response.json();
@@ -18,8 +17,8 @@ fetch('https://yzapi.yazio.com/v5/oauth/token', {method: 'post', body: body})
   .then(response => {
     console.debug(response);
   }).catch(error => {
-  console.error(error);
-});
+    console.error(error);
+  });
 
 /*
 Json response:

--- a/swagger.json
+++ b/swagger.json
@@ -16,7 +16,11 @@
         { "name": "products", "description": "Food product search and detail" },
         { "name": "diary",    "description": "User food diary (consumed items)" },
         { "name": "summary",  "description": "Daily nutrition summary widgets" },
-        { "name": "water",    "description": "Water intake tracking" }
+        { "name": "water",    "description": "Water intake tracking" },
+        { "name": "exercises",  "description": "User exercise and training log" },
+        { "name": "goals",      "description": "User nutrition and activity goals" },
+        { "name": "settings",   "description": "User app settings and preferences" },
+        { "name": "bodyvalues", "description": "Body measurements (weight, etc.)" }
     ],
     "schemes": ["https"],
     "securityDefinitions": {
@@ -213,6 +217,106 @@
                     "200": { "description": "Water intake logged successfully" }
                 }
             }
+        },
+        "/user/dietary-preferences": {
+            "get": {
+                "tags": ["user"],
+                "summary": "Get dietary preferences",
+                "description": "Returns the user's dietary restriction (e.g. vegetarian, vegan).",
+                "security": [{ "oauth2": [] }],
+                "responses": {
+                    "200": {
+                        "description": "Dietary preferences",
+                        "schema": { "$ref": "#/definitions/UserDietaryPreferences" }
+                    }
+                }
+            }
+        },
+        "/user/exercises": {
+            "get": {
+                "tags": ["exercises"],
+                "summary": "Get exercises for a date",
+                "description": "Returns training and custom_training entries logged by the user for a specific day.",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "date", "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Exercise entries",
+                        "schema": { "$ref": "#/definitions/UserExercisesResponse" }
+                    }
+                }
+            }
+        },
+        "/user/goals/unmodified": {
+            "get": {
+                "tags": ["goals"],
+                "summary": "Get user goals for a date",
+                "description": "Returns calorie, macro, water, step, and weight goals for the specified day.",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "date", "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User goals",
+                        "schema": { "$ref": "#/definitions/UserGoals" }
+                    }
+                }
+            }
+        },
+        "/user/settings": {
+            "get": {
+                "tags": ["settings"],
+                "summary": "Get user settings",
+                "description": "Returns boolean feature flags for trackers, reminders, and other app settings.",
+                "security": [{ "oauth2": [] }],
+                "responses": {
+                    "200": {
+                        "description": "User settings",
+                        "schema": { "$ref": "#/definitions/UserSettings" }
+                    }
+                }
+            }
+        },
+        "/user/bodyvalues/weight/last": {
+            "get": {
+                "tags": ["bodyvalues"],
+                "summary": "Get last weight entry",
+                "description": "Returns the most recent weight entry for the user on or before the given date, or null if none exists.",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "date", "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Weight entry or null",
+                        "schema": { "$ref": "#/definitions/UserWeight" }
+                    }
+                }
+            }
+        },
+        "/user/products/suggested": {
+            "get": {
+                "tags": ["products"],
+                "summary": "Get suggested products for a meal slot",
+                "description": "Returns products suggested for the user based on their history for a specific date and meal (daytime).",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "date",    "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" },
+                    { "name": "daytime", "in": "query", "required": true, "type": "string", "enum": ["breakfast", "lunch", "dinner", "snack"] }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Suggested products",
+                        "schema": {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/UserSuggestedProduct" }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -354,6 +458,84 @@
             "properties": {
                 "date":         { "type": "string", "example": "2024-01-15 08:30:00" },
                 "water_intake": { "type": "number", "description": "Water intake in millilitres" }
+            }
+        },
+        "UserDietaryPreferences": {
+            "type": "object",
+            "properties": {
+                "restriction": { "type": "string", "nullable": true, "example": "vegetarian", "description": "Dietary restriction label, or null if none" }
+            }
+        },
+        "Exercise": {
+            "type": "object",
+            "properties": {
+                "id":          { "type": "string", "format": "uuid" },
+                "note":        { "type": "string", "nullable": true },
+                "date":        { "type": "string", "example": "2024-01-15 08:00:00" },
+                "name":        { "type": "string" },
+                "external_id": { "type": "string", "nullable": true },
+                "energy":      { "type": "number", "description": "Calories burned" },
+                "distance":    { "type": "number" },
+                "duration":    { "type": "number", "description": "Duration in seconds" },
+                "source":      { "type": "string", "nullable": true },
+                "gateway":     { "type": "string", "nullable": true },
+                "steps":       { "type": "number" }
+            }
+        },
+        "UserExercisesResponse": {
+            "type": "object",
+            "properties": {
+                "training":        { "type": "array", "items": { "$ref": "#/definitions/Exercise" } },
+                "custom_training": { "type": "array", "items": { "$ref": "#/definitions/Exercise" } }
+            }
+        },
+        "UserGoals": {
+            "type": "object",
+            "description": "Daily goals for the user",
+            "properties": {
+                "energy.energy":      { "type": "number", "description": "Calorie goal in kcal" },
+                "nutrient.protein":   { "type": "number", "description": "Protein goal in grams" },
+                "nutrient.fat":       { "type": "number", "description": "Fat goal in grams" },
+                "nutrient.carb":      { "type": "number", "description": "Carbohydrate goal in grams" },
+                "activity.step":      { "type": "number", "description": "Step count goal" },
+                "bodyvalue.weight":   { "type": "number", "description": "Target weight in kg" },
+                "water":              { "type": "number", "description": "Water intake goal in ml" }
+            }
+        },
+        "UserSettings": {
+            "type": "object",
+            "properties": {
+                "has_water_tracker":               { "type": "boolean" },
+                "has_diary_tipps":                 { "type": "boolean" },
+                "has_meal_reminders":              { "type": "boolean" },
+                "has_usage_reminders":             { "type": "boolean" },
+                "has_weight_reminders":            { "type": "boolean" },
+                "has_water_reminders":             { "type": "boolean" },
+                "consume_activity_calories":       { "type": "boolean" },
+                "has_feelings":                    { "type": "boolean" },
+                "has_fasting_tracker_reminders":   { "type": "boolean" },
+                "has_fasting_stage_reminders":     { "type": "boolean" }
+            }
+        },
+        "UserWeight": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+                "id":          { "type": "string", "format": "uuid" },
+                "date":        { "type": "string", "example": "2024-01-15 08:00:00" },
+                "value":       { "type": "number", "nullable": true, "description": "Weight in kg" },
+                "external_id": { "type": "string", "nullable": true },
+                "gateway":     { "type": "string", "nullable": true },
+                "source":      { "type": "string", "nullable": true }
+            }
+        },
+        "UserSuggestedProduct": {
+            "type": "object",
+            "properties": {
+                "product_id":       { "type": "string", "format": "uuid" },
+                "amount":           { "type": "number", "description": "Amount in grams" },
+                "serving":          { "type": "string", "nullable": true },
+                "serving_quantity": { "type": "number", "nullable": true }
             }
         }
     }

--- a/swagger.json
+++ b/swagger.json
@@ -305,7 +305,7 @@
                 "security": [{ "oauth2": [] }],
                 "parameters": [
                     { "name": "date",    "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" },
-                    { "name": "daytime", "in": "query", "required": true, "type": "string", "enum": ["breakfast", "lunch", "dinner", "snack"] }
+                    { "name": "daytime", "in": "query", "required": true, "type": "string", "enum": ["breakfast", "lunch", "dinner", "snack"], "description": "Meal slot to get suggestions for" }
                 ],
                 "responses": {
                     "200": {
@@ -463,22 +463,22 @@
         "UserDietaryPreferences": {
             "type": "object",
             "properties": {
-                "restriction": { "type": "string", "nullable": true, "example": "vegetarian", "description": "Dietary restriction label, or null if none" }
+                "restriction": { "type": "string", "x-nullable": true, "example": "vegetarian", "description": "Dietary restriction label, or null if none" }
             }
         },
         "Exercise": {
             "type": "object",
             "properties": {
-                "id":          { "type": "string", "format": "uuid" },
-                "note":        { "type": "string", "nullable": true },
+                "id":          { "type": "string" },
+                "note":        { "type": "string", "x-nullable": true },
                 "date":        { "type": "string", "example": "2024-01-15 08:00:00" },
                 "name":        { "type": "string" },
-                "external_id": { "type": "string", "nullable": true },
+                "external_id": { "type": "string", "x-nullable": true },
                 "energy":      { "type": "number", "description": "Calories burned" },
                 "distance":    { "type": "number" },
                 "duration":    { "type": "number", "description": "Duration in seconds" },
-                "source":      { "type": "string", "nullable": true },
-                "gateway":     { "type": "string", "nullable": true },
+                "source":      { "type": "string", "x-nullable": true },
+                "gateway":     { "type": "string", "x-nullable": true },
                 "steps":       { "type": "number" }
             }
         },
@@ -519,23 +519,23 @@
         },
         "UserWeight": {
             "type": "object",
-            "nullable": true,
+            "description": "Weight entry, or null if no entry exists for the given date.",
             "properties": {
-                "id":          { "type": "string", "format": "uuid" },
+                "id":          { "type": "string" },
                 "date":        { "type": "string", "example": "2024-01-15 08:00:00" },
-                "value":       { "type": "number", "nullable": true, "description": "Weight in kg" },
-                "external_id": { "type": "string", "nullable": true },
-                "gateway":     { "type": "string", "nullable": true },
-                "source":      { "type": "string", "nullable": true }
+                "value":       { "type": "number", "x-nullable": true, "description": "Weight in kg" },
+                "external_id": { "type": "string", "x-nullable": true },
+                "gateway":     { "type": "string", "x-nullable": true },
+                "source":      { "type": "string", "x-nullable": true }
             }
         },
         "UserSuggestedProduct": {
             "type": "object",
             "properties": {
-                "product_id":       { "type": "string", "format": "uuid" },
+                "product_id":       { "type": "string" },
                 "amount":           { "type": "number", "description": "Amount in grams" },
-                "serving":          { "type": "string", "nullable": true },
-                "serving_quantity": { "type": "number", "nullable": true }
+                "serving":          { "type": "string", "x-nullable": true },
+                "serving_quantity": { "type": "number", "x-nullable": true }
             }
         }
     }

--- a/swagger.json
+++ b/swagger.json
@@ -1,341 +1,360 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "This is a sample server for Yazio API.",
-        "version": "1.0.0",
-        "title": "Yazio API",
-        "termsOfService": "http://swagger.io/terms/",
+        "description": "Community-maintained documentation of the unofficial YAZIO fitness app API (v15). YAZIO has not published an official API — this is reverse-engineered from working app traffic.",
+        "version": "15.0.0",
+        "title": "YAZIO API",
         "contact": {
-            "email": "apiteam@swagger.io"
+            "url": "https://github.com/saganos/yazio_public_api"
         }
     },
-    "host": "api.yazio.com",
-    "basePath": "/v1",
+    "host": "yzapi.yazio.com",
+    "basePath": "/v15",
     "tags": [
-        {
-            "name": "auth",
-            "description": "Authentication related endpoints"
-        },
-        {
-            "name": "meals",
-            "description": "Meal management endpoints"
-        },
-        {
-            "name": "nutrients",
-            "description": "Nutrient information endpoints"
+        { "name": "auth",     "description": "Authentication — obtain and refresh access tokens" },
+        { "name": "user",     "description": "User profile and account information" },
+        { "name": "products", "description": "Food product search and detail" },
+        { "name": "diary",    "description": "User food diary (consumed items)" },
+        { "name": "summary",  "description": "Daily nutrition summary widgets" },
+        { "name": "water",    "description": "Water intake tracking" }
+    ],
+    "schemes": ["https"],
+    "securityDefinitions": {
+        "oauth2": {
+            "type": "oauth2",
+            "flow": "password",
+            "tokenUrl": "https://yzapi.yazio.com/v15/oauth/token",
+            "scopes": {}
         }
-    ],
-    "schemes": [
-        "https"
-    ],
+    },
     "paths": {
-        "/login": {
+        "/oauth/token": {
             "post": {
-                "tags": [
-                    "auth"
-                ],
-                "summary": "User login",
-                "description": "Login to Yazio App with username and password using OAuth2.",
+                "tags": ["auth"],
+                "summary": "Obtain or refresh an access token",
+                "description": "Use grant_type=password to log in, or grant_type=refresh_token to renew an existing session. Request body must be application/x-www-form-urlencoded.",
+                "consumes": ["application/x-www-form-urlencoded"],
                 "parameters": [
-                    {
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/Login"
-                        }
-                    }
+                    { "name": "grant_type",    "in": "formData", "required": true,  "type": "string", "enum": ["password", "refresh_token"] },
+                    { "name": "client_id",     "in": "formData", "required": true,  "type": "string" },
+                    { "name": "client_secret", "in": "formData", "required": true,  "type": "string" },
+                    { "name": "username",      "in": "formData", "required": false, "type": "string", "description": "Required when grant_type is password" },
+                    { "name": "password",      "in": "formData", "required": false, "type": "string", "description": "Required when grant_type is password" },
+                    { "name": "refresh_token", "in": "formData", "required": false, "type": "string", "description": "Required when grant_type is refresh_token" }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful login",
-                        "schema": {
-                            "$ref": "#/definitions/AuthResponse"
-                        }
+                        "description": "Access token issued",
+                        "schema": { "$ref": "#/definitions/AuthResponse" }
                     }
                 }
             }
         },
-        "/token_refresh": {
-            "post": {
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Refresh token",
-                "description": "Refreshes the authentication token.",
-                "parameters": [
-                    {
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/TokenRefresh"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Token refreshed",
-                        "schema": {
-                            "$ref": "#/definitions/AuthResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/user_info": {
+        "/user": {
             "get": {
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Get user info",
-                "description": "Retrieves user information.",
+                "tags": ["user"],
+                "summary": "Get user profile",
+                "description": "Returns the authenticated user's account and preference data.",
+                "security": [{ "oauth2": [] }],
                 "responses": {
                     "200": {
-                        "description": "Successful retrieval",
+                        "description": "User profile",
+                        "schema": { "$ref": "#/definitions/UserInfo" }
+                    }
+                }
+            }
+        },
+        "/products/search": {
+            "get": {
+                "tags": ["products"],
+                "summary": "Search food products",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "query",     "in": "query", "required": true,  "type": "string", "description": "Search term" },
+                    { "name": "sex",       "in": "query", "required": false, "type": "string", "enum": ["male", "female"] },
+                    { "name": "countries", "in": "query", "required": false, "type": "string", "description": "ISO 3166-1 alpha-2 country code, e.g. DE" },
+                    { "name": "locales",   "in": "query", "required": false, "type": "string", "description": "IETF locale tag, e.g. de_DE" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Array of matching products",
                         "schema": {
-                            "$ref": "#/definitions/UserInfo"
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/SearchResult" }
                         }
                     }
                 }
             }
         },
-        "/share_meal": {
-            "post": {
-                "tags": [
-                    "meals"
+        "/products/{id}": {
+            "get": {
+                "tags": ["products"],
+                "summary": "Get product details",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "id", "in": "path", "required": true, "type": "string" }
                 ],
-                "summary": "Share meal",
-                "description": "Share saved meal with other users.",
+                "responses": {
+                    "200": {
+                        "description": "Product detail",
+                        "schema": { "$ref": "#/definitions/ProductDetail" }
+                    }
+                }
+            }
+        },
+        "/user/consumed-items": {
+            "get": {
+                "tags": ["diary"],
+                "summary": "Get diary entries for a date",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "date", "in": "query", "required": true, "type": "string", "format": "date", "description": "e.g. 2024-01-15" }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Consumed items for the day",
+                        "schema": {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/ConsumedItem" }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": ["diary"],
+                "summary": "Add items to diary",
+                "security": [{ "oauth2": [] }],
+                "consumes": ["application/json"],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": { "$ref": "#/definitions/ConsumedItemsRequest" }
+                    }
+                ],
+                "responses": {
+                    "200": { "description": "Items logged successfully" }
+                }
+            },
+            "delete": {
+                "tags": ["diary"],
+                "summary": "Delete diary entries by ID",
+                "security": [{ "oauth2": [] }],
+                "consumes": ["application/json"],
                 "parameters": [
                     {
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/ShareMeal"
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Array of consumed-item IDs to delete"
                         }
                     }
                 ],
                 "responses": {
+                    "200": { "description": "Items deleted successfully" }
+                }
+            }
+        },
+        "/user/widgets/daily-summary": {
+            "get": {
+                "tags": ["summary"],
+                "summary": "Get daily nutrition summary",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "date", "in": "query", "required": true, "type": "string", "format": "date" }
+                ],
+                "responses": {
                     "200": {
-                        "description": "Meal shared",
-                        "schema": {
-                            "$ref": "#/definitions/ShareMealResponse"
-                        }
+                        "description": "Daily nutrition summary",
+                        "schema": { "$ref": "#/definitions/DailySummary" }
                     }
                 }
             }
         },
-        "/log_meal": {
-            "post": {
-                "tags": [
-                    "meals"
+        "/user/water-intake": {
+            "get": {
+                "tags": ["water"],
+                "summary": "Get water intake for a date",
+                "security": [{ "oauth2": [] }],
+                "parameters": [
+                    { "name": "date", "in": "query", "required": true, "type": "string", "format": "date" }
                 ],
-                "summary": "Log a meal",
-                "description": "Log a meal for the user.",
+                "responses": {
+                    "200": {
+                        "description": "Water intake entries",
+                        "schema": {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/WaterIntakeEntry" }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": ["water"],
+                "summary": "Log water intake",
+                "security": [{ "oauth2": [] }],
+                "consumes": ["application/json"],
                 "parameters": [
                     {
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/LogMeal"
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/WaterIntakeEntry" }
                         }
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "Meal logged",
-                        "schema": {
-                            "$ref": "#/definitions/LogMealResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/get_meals": {
-            "get": {
-                "tags": [
-                    "meals"
-                ],
-                "summary": "Get meals",
-                "description": "Retrieve meals logged by the user.",
-                "responses": {
-                    "200": {
-                        "description": "Successful retrieval",
-                        "schema": {
-                            "$ref": "#/definitions/Meals"
-                        }
-                    }
-                }
-            }
-        },
-        "/nutrients_info": {
-            "get": {
-                "tags": [
-                    "nutrients"
-                ],
-                "summary": "Get nutrient information",
-                "description": "Get detailed nutrient information.",
-                "responses": {
-                    "200": {
-                        "description": "Successful retrieval",
-                        "schema": {
-                            "$ref": "#/definitions/NutrientsInfo"
-                        }
-                    }
+                    "200": { "description": "Water intake logged successfully" }
                 }
             }
         }
     },
     "definitions": {
-        "Login": {
-            "type": "object",
-            "required": [
-                "username",
-                "password"
-            ],
-            "properties": {
-                "username": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                }
-            }
-        },
         "AuthResponse": {
             "type": "object",
             "properties": {
-                "token": {
-                    "type": "string"
-                }
-            }
-        },
-        "TokenRefresh": {
-            "type": "object",
-            "required": [
-                "token"
-            ],
-            "properties": {
-                "token": {
-                    "type": "string"
-                }
+                "access_token":  { "type": "string" },
+                "token_type":    { "type": "string", "example": "bearer" },
+                "expires_in":    { "type": "integer", "example": 172800, "description": "Token lifetime in seconds" },
+                "refresh_token": { "type": "string" }
             }
         },
         "UserInfo": {
             "type": "object",
             "properties": {
-                "id": {
-                    "type": "string"
+                "email":                      { "type": "string" },
+                "first_name":                 { "type": "string" },
+                "last_name":                  { "type": "string" },
+                "sex":                        { "type": "string" },
+                "date_of_birth":              { "type": "string", "example": "1983-05-06" },
+                "body_height":                { "type": "number" },
+                "start_weight":               { "type": "number" },
+                "goal":                       { "type": "string", "example": "lose" },
+                "is_premium":                 { "type": "boolean" },
+                "pal":                        { "type": "number" },
+                "locale":                     { "type": "string", "example": "en_US" },
+                "timezone_offset":            { "type": "integer" },
+                "unit_length":                { "type": "string", "example": "cm" },
+                "unit_mass":                  { "type": "string", "example": "kg" },
+                "unit_energy":                { "type": "string", "example": "kcal" },
+                "unit_glucose":               { "type": "string" },
+                "unit_serving":               { "type": "string" },
+                "registration_date":          { "type": "string" },
+                "last_active_date":           { "type": "string" },
+                "user_token":                 { "type": "string" },
+                "login_type":                 { "type": "string" },
+                "email_confirmation_status":  { "type": "string" },
+                "profile_image":              { "type": "string" },
+                "siwa_user_id":               { "type": "string" },
+                "diet": {
+                    "type": "object",
+                    "properties": {
+                        "name":               { "type": "string" },
+                        "carb_percentage":    { "type": "integer" },
+                        "fat_percentage":     { "type": "integer" },
+                        "protein_percentage": { "type": "integer" }
+                    }
+                }
+            }
+        },
+        "ProductNutrients": {
+            "type": "object",
+            "description": "Nutrient values are per gram of the product",
+            "properties": {
+                "energy.energy":    { "type": "number", "description": "Energy in kcal per gram" },
+                "nutrient.protein": { "type": "number", "description": "Protein in grams per gram" },
+                "nutrient.fat":     { "type": "number", "description": "Fat in grams per gram" },
+                "nutrient.carb":    { "type": "number", "description": "Carbohydrates in grams per gram" }
+            }
+        },
+        "ProductServing": {
+            "type": "object",
+            "properties": {
+                "serving": { "type": "string" },
+                "amount":  { "type": "number", "description": "Amount in grams" }
+            }
+        },
+        "ProductDetail": {
+            "type": "object",
+            "properties": {
+                "name":      { "type": "string" },
+                "producer":  { "type": "string" },
+                "category":  { "type": "string" },
+                "base_unit": { "type": "string" },
+                "nutrients": { "$ref": "#/definitions/ProductNutrients" },
+                "servings":  { "type": "array", "items": { "$ref": "#/definitions/ProductServing" } }
+            }
+        },
+        "SearchResult": {
+            "type": "object",
+            "properties": {
+                "product_id":       { "type": "string" },
+                "name":             { "type": "string" },
+                "producer":         { "type": "string" },
+                "serving":          { "type": "string" },
+                "serving_quantity": { "type": "number" },
+                "amount":           { "type": "number", "description": "Default serving amount in grams" },
+                "base_unit":        { "type": "string" },
+                "nutrients":        { "$ref": "#/definitions/ProductNutrients" },
+                "is_verified":      { "type": "boolean" }
+            }
+        },
+        "ConsumedItem": {
+            "type": "object",
+            "properties": {
+                "id":               { "type": "string" },
+                "product_id":       { "type": "string" },
+                "date":             { "type": "string", "example": "2024-01-15 08:30:00" },
+                "daytime":          { "type": "string", "enum": ["breakfast", "lunch", "dinner", "snack"] },
+                "amount":           { "type": "number", "description": "Amount in grams" },
+                "serving":          { "type": "string" },
+                "serving_quantity": { "type": "number" }
+            }
+        },
+        "ConsumedItemsRequest": {
+            "type": "object",
+            "properties": {
+                "products":        { "type": "array", "items": { "$ref": "#/definitions/ConsumedItem" } },
+                "recipe_portions": { "type": "array", "items": {}, "description": "Recipe portions to log (pass empty array if unused)" },
+                "simple_products": { "type": "array", "items": {}, "description": "Simple products to log (pass empty array if unused)" }
+            }
+        },
+        "DailySummary": {
+            "type": "object",
+            "description": "Daily nutrition totals and goals from the user's diary",
+            "properties": {
+                "goals": {
+                    "type": "object",
+                    "properties": {
+                        "energy.energy":    { "type": "number" },
+                        "nutrient.protein": { "type": "number" },
+                        "nutrient.fat":     { "type": "number" },
+                        "nutrient.carb":    { "type": "number" }
+                    }
                 },
-                "username": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                }
-            }
-        },
-        "ShareMeal": {
-            "type": "object",
-            "required": [
-                "mealId",
-                "recipientId"
-            ],
-            "properties": {
-                "mealId": {
-                    "type": "string"
-                },
-                "recipientId": {
-                    "type": "string"
-                }
-            }
-        },
-        "ShareMealResponse": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "LogMeal": {
-            "type": "object",
-            "required": [
-                "mealDetails"
-            ],
-            "properties": {
-                "mealDetails": {
-                    "type": "string"
-                }
-            }
-        },
-        "LogMealResponse": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "Meals": {
-            "type": "object",
-            "properties": {
                 "meals": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Meal"
+                    "type": "object",
+                    "properties": {
+                        "breakfast": { "type": "object", "properties": { "energy_goal": { "type": "number" } } },
+                        "lunch":     { "type": "object", "properties": { "energy_goal": { "type": "number" } } },
+                        "dinner":    { "type": "object", "properties": { "energy_goal": { "type": "number" } } },
+                        "snack":     { "type": "object", "properties": { "energy_goal": { "type": "number" } } }
                     }
                 }
             }
         },
-        "Meal": {
+        "WaterIntakeEntry": {
             "type": "object",
             "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "details": {
-                    "type": "string"
-                }
-            }
-        },
-        "NutrientsInfo": {
-            "type": "object",
-            "properties": {
-                "nutrients": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Nutrient"
-                    }
-                }
-            }
-        },
-        "Nutrient": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "amount": {
-                    "type": "string"
-                }
+                "date":         { "type": "string", "example": "2024-01-15 08:30:00" },
+                "water_intake": { "type": "number", "description": "Water intake in millilitres" }
             }
         }
-    },
-    "securityDefinitions": {
-        "oauth2": {
-            "type": "oauth2",
-            "flow": "password",
-            "tokenUrl": "https://yzapi.yazio.com/v12/oauth/token",
-            "scopes": {}
-        }
-    },
-    "security": [
-        {
-            "oauth2": []
-        }
-    ]
+    }
 }


### PR DESCRIPTION
## Summary

- Updates all API endpoint URLs from v5 to v15 (`yzapi.yazio.com/v15`)
- Fixes OAuth token request to use `application/x-www-form-urlencoded` instead of JSON (required by v15)
- Rewrites `swagger.json` with confirmed v15 endpoints: `/oauth/token`, `/user`, `/products/search`, `/products/{id}`, `/user/consumed-items` (GET/POST/DELETE), `/user/widgets/daily-summary`, `/user/water-intake` (GET/POST)
- Adds new example scripts: `search_products.js`, `get_diary.js`
- Updates `securityDefinitions` tokenUrl from v12 to v15

Closes #1

## Test plan

- [ ] `node examples/login.js` (with real credentials) returns `{ access_token, refresh_token, ... }`
- [ ] `node examples/token_refresh.js` (with valid refresh token) returns a new access token
- [ ] `node examples/get_user_info.js` (with valid bearer token) returns user profile object
- [ ] `node examples/search_products.js` (with valid bearer token) returns array of product results
- [ ] `node examples/get_diary.js` (with valid bearer token and real date) returns diary entries
- [ ] `swagger.json` imports cleanly into https://editor-next.swagger.io/

🤖 Generated with [Claude Code](https://claude.com/claude-code)